### PR TITLE
Default displayed tab from URL query parameter

### DIFF
--- a/resources/js/components/DetailTabs.vue
+++ b/resources/js/components/DetailTabs.vue
@@ -98,7 +98,16 @@ export default {
       tabs[field.tab].fields.push(field);
     });
     this.tabs = tabs;
-    this.handleTabClick(tabs[Object.keys(tabs)[0]]);
+    if(!_.isUndefined(this.$route.query.tabName)) {
+        if(_.isUndefined(tabs[this.$route.query.tabName])) {
+            this.handleTabClick(tabs[Object.keys(tabs)[0]]);
+        } else {
+            this.activeTab = this.$route.query.tabName;
+            this.handleTabClick(tabs[this.$route.query.tabName]);
+        }
+    } else {
+        this.handleTabClick(tabs[Object.keys(tabs)[0]]);
+    }
   },
   methods: {
     /**


### PR DESCRIPTION
This adds the ability to pass a query parameter in the URL to set the default selected and displayed tab on a resource details view upon route change.

To use this simply add a `tabName` query parameter to your router-link `:to=` prop.

### Example
`<router-link :to='{ name: 'detail', params: { resourceName: 'sales', resourceId: sale_id }, query: { tabName: 'Name of your Tab' }}'></router-link>`