### PR TITLE
Fix withMeta not exists on MissingValue

### DIFF
--- a/src/Tabs.php
+++ b/src/Tabs.php
@@ -5,6 +5,7 @@ use RuntimeException;
 use Laravel\Nova\Panel;
 use Illuminate\Http\Resources\MergeValue;
 use Laravel\Nova\Contracts\ListableField;
+use Illuminate\Http\Resources\MissingValue;
 
 class Tabs extends Panel
 {
@@ -30,10 +31,15 @@ class Tabs extends Panel
                 $this->addFields($tab, $field->data);
                 continue;
             }
+
             $field->panel = $this->name;
-            $field->withMeta([
-                'tab' => $tab,
-            ]);
+
+            if (! $field instanceof MissingValue) {
+                $field->withMeta([
+                    'tab' => $tab,
+                ]);
+            }
+
             $this->data[] = $field;
         }
 


### PR DESCRIPTION
Since a lot of time I did create this issue #31 and I found a workaround but it didn't fix most of the cases when you need to use the Nova's methods: merge/mergeWhen