### PR TITLE
add request as the first parameter as Nova expects

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
     ],
     "license": "MIT",
     "require": {
-        "php": ">=7.1.0"
+        "php": ">=7.1.0",
+        "laravel/nova": "^2.1.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/TabsOnEdit.php
+++ b/src/TabsOnEdit.php
@@ -19,7 +19,7 @@ trait TabsOnEdit
             [
                 'Tabs' => [
                     'component' => 'tabs',
-                    'fields'    => $this->removeNonCreationFields($this->resolveFields($request)),
+                    'fields'    => $this->removeNonCreationFields($request, $this->resolveFields($request)),
                     'panel'     => Panel::defaultNameForCreate($request->newResource()),
                 ],
             ]
@@ -109,7 +109,7 @@ trait TabsOnEdit
             [
                 'Tabs' => [
                     'component' => 'tabs',
-                    'fields'    => $this->removeNonUpdateFields($this->resolveFields($request)),
+                    'fields'    => $this->removeNonUpdateFields($request, $this->resolveFields($request)),
                     'panel'     => Panel::defaultNameForUpdate($request->newResource()),
                 ],
             ]


### PR DESCRIPTION
Nova now expects the request as the first parameter in the removeNonCreationFields and removeNonUpdateFields methods.

Fixes: https://github.com/eminiarts/nova-tabs/issues/48