### PR TITLE
Fixed reset of mb-6

### DIFF
--- a/resources/js/components/DetailTabs.vue
+++ b/resources/js/components/DetailTabs.vue
@@ -191,13 +191,13 @@ export default {
     height: 62px;
     z-index: 1;
 
-    > .mb-6 {
-      margin-bottom: 0;
-    }
-
     > .w-full {
       width: auto;
       margin-left: 1.5rem;
+
+      > .mb-6 {
+        margin-bottom: 0;
+      }
     }
   }
 }


### PR DESCRIPTION
On latest versions of Nova **Create** or **Attach** buttons on details page moved to nested of additional `div`, so `mb-6` reset to 0 doesn't affect:

![screentshot](https://image.prntscr.com/image/hr6-5I6FSbmTvjsoGHlCGA.png)

in dom:

![screentshot](https://image.prntscr.com/image/2ZtdnvWaQLCMK7nYmLqnWw.png)