### PR TITLE
Fix resource not loaded during update validation

### DIFF
--- a/src/TabsOnEdit.php
+++ b/src/TabsOnEdit.php
@@ -121,8 +121,9 @@ trait TabsOnEdit
      */
     public static function rulesForUpdate(NovaRequest $request, $resource = null)
     {
-        return static::formatRules($request, (new static(static::newModel()))
-                ->parentUpdateFields($request)
+        $resource = $resource ?? self::newResource();
+
+        return static::formatRules($request, $resource->parentUpdateFields($request)
                 ->mapWithKeys(function ($field) use ($request) {
                     return $field->getUpdateRules($request);
                 })->all());


### PR DESCRIPTION
This commit fixes an issue where the resources properties (like the id)
were not populated in computed fields during updates while using the
TabsOnEdit trait.

The change is in a method that is overwritten from Nova, and is
basically a copy paste from that method (Nova version 3.15.0).

I hope the change is as obviously "correct" as I think it is. Otherwise
let me know if I can provide any additional info.