### PR TITLE
Fixed issue with update rules not using existing resource

### DIFF
--- a/src/TabsOnEdit.php
+++ b/src/TabsOnEdit.php
@@ -117,7 +117,9 @@ trait TabsOnEdit
      */
     public static function rulesForUpdate(NovaRequest $request, $resource = null)
     {
-        return static::formatRules($request, (new static(static::newModel()))
+        $resource = $resource ?? self::newResource();
+
+        return static::formatRules($request, $resource
                 ->parentUpdateFields($request)
                 ->mapWithKeys(function ($field) use ($request) {
                     return $field->getUpdateRules($request);


### PR DESCRIPTION
This PR fixes an issue with the update rules when using the TabsOnEdit trait on a resource.
The TabsOnEdit trait currently breaks validation rules that rely on the model when updating the model.

Example of a case that is fixed by this PR:  
```
Text::make(__('Number'),  'number')
    ->rules([
        'required', 
        'integer', 
        Rule::unique('modules')
            ->ignoreModel($this->resource),
    ]),
```
