### PR TITLE
Added Dusk Selector(s) to FormTab & DetailTabs

### DIFF
--- a/resources/js/components/DetailTabs.vue
+++ b/resources/js/components/DetailTabs.vue
@@ -11,6 +11,7 @@
                         :class="getTabClass(tab)"
                         v-for="(tab, key) in tabs"
                         :key="key"
+                        :dusk="tab.slug + '-tab'"
                         @click="handleTabClick(tab)"
                     >
                         <tab-title :tab="tab" />

--- a/resources/js/components/FormTabs.vue
+++ b/resources/js/components/FormTabs.vue
@@ -6,6 +6,7 @@
                 class="py-5 px-8 border-b-2 focus:outline-none tab cursor-pointer flex items-center"
                 :class="getTabClass(tab)"
                 :key="key"
+                :dusk="tab.slug + '-tab'"
                 @click="handleTabClick(tab, $event)"
             >
                 <tab-title :tab="tab" />


### PR DESCRIPTION
Added dusks selector property to the FormTab component to make Tabs easier test-able with Laravel Dusk to avoid that changing CSS selectors cause broken tests.

The selector uses a slug of the tab name suffixed with the "-tab" string to avoid name conflicts with other components.