### PR TITLE
Fix loss of parent slug

### DIFF
--- a/src/Tabs.php
+++ b/src/Tabs.php
@@ -52,7 +52,11 @@ class Tabs extends Panel
                 }
 
                 $this->addFields(
-                    new Tab($tab->getTitle(), $field->data)
+                    tap(new Tab($tab->getTitle(), $field->data), function(TabContract $newTab) use ($tab){
+                        if ($tab->getName() !== $tab->getTitle()) {
+                            $newTab->name($tab->getName());
+                        }
+                    })
                 );
                 continue;
             }


### PR DESCRIPTION
In case of using a third-party field inherited from `Illuminate\Http\Resources\MergeValue` the Tab is losing slug.

## Example

We used [naoray/nova-json](https://github.com/Naoray/nova-json)

```php
// in app/Nova/Resource.php

use Eminiarts\Tabs\Tabs;
use Eminiarts\Tabs\Tab;
use Naoray\NovaJson\JSON;

public function fields()
{
    return [
        Tabs::make('Tabs', [
            Tab::make('Settings', [
                JSON::make('Some Json Column Name', [
                    Text::make('First Field'),
                    Text::make('Second Field'),
                    Text::make('Third Field'),
                ]);
            ])->name('tab-slug'),
        ]),
    ];
}
```

In this case slug of tab **Settings** will be `settings`, not `tab-slug`.
Kind of weird.

This PR fixes this situation. 

