### PR TITLE
Default to showing a toolbar on the first generated panel that contai…

### DIFF
--- a/src/Traits/HasTabs.php
+++ b/src/Traits/HasTabs.php
@@ -88,7 +88,7 @@ trait HasTabs
                 );
             })
             ->tap(function ($panels) use ($label): void {
-                $panels->where('component', 'tabs')->first();
+                $panels->where('component', 'tabs')->isEmpty() ? $panels->where('component', 'tabs')->first() : $panels->first()->withToolbar();
             });
     }
 }


### PR DESCRIPTION
#189
Default to showing a toolbar on the first generated panel that contains the attribute fields not captured in a tab-panel.
Will not show the toolbar if a tab is used for attributes. Then ->withToolbar() can be called on the tabs object.