### PR TITLE
Make tab styling consistent between edit and details view.

### DIFF
--- a/resources/js/components/FormTabs.vue
+++ b/resources/js/components/FormTabs.vue
@@ -29,7 +29,7 @@
                 :class="getIsTabCurrent(tab) ? 'active tabs-text-' + getCurrentColor() + '-500 tabs-font-bold tabs-border-b-2 tabs-border-b-' + getCurrentColor() + '-500' : 'tabs-text-gray-600 hover:tabs-text-gray-800 dark:tabs-text-gray-400 hover:dark:tabs-text-gray-200'"
                 :dusk="tab.slug + '-tab'"
                 :ref="tab.slug + '-tab'"
-                class="tab-item"
+                class="tab-item border-gray-200"
                 @click.prevent="handleTabClick(tab)"
               >
                 <span class="capitalize">{{ tab.properties.title }}</span>


### PR DESCRIPTION
This change to line 32 of FormTabs.vue makes it consistent with [line 31 of DetailTabs.vue](https://github.com/eminiarts/nova-tabs/blob/bcc616863e20522099488285915141b51741c5eb/resources/js/components/DetailTabs.vue#L31).

Currently there is a difference in how the two are displayed – on the edit view, the border between adjacent tabs is darker than it it is on the detail view.