### PR TITLE
Feature: Add the ability to specify how slugs are generated

### DIFF
--- a/src/Tab.php
+++ b/src/Tab.php
@@ -37,6 +37,9 @@ class Tab implements TabContract, JsonSerializable, Arrayable
 
     protected $position;
 
+    /** @var null|callable(\Eminiarts\Tabs\Contracts\TabContract $tab): string */
+    protected static $createSlugUsing = null;
+
     public function __construct($title, array $fields, $position = 0)
     {
         $this->title = $title;
@@ -47,6 +50,12 @@ class Tab implements TabContract, JsonSerializable, Arrayable
     public static function make($title, array $fields): self
     {
         return new static($title, $fields);
+    }
+
+    /** @param callable(\Eminiarts\Tabs\Contracts\TabContract $tab): string $createSlugUsingFunction */
+    public static function createSlugUsing(callable $createSlugUsingFunction): void
+    {
+        self::$createSlugUsing = $createSlugUsingFunction;
     }
 
     public function position(int $position): self
@@ -157,6 +166,10 @@ class Tab implements TabContract, JsonSerializable, Arrayable
 
     public function getSlug(): string
     {
+        if (null !== $makeSlug = static::$createSlugUsing) {
+            return $makeSlug($this);
+        }
+
         return Str::slug($this->getName());
     }
 

--- a/tests/Feature/TabTest.php
+++ b/tests/Feature/TabTest.php
@@ -6,6 +6,7 @@ namespace Eminiarts\Tabs\Tests\Feature;
 
 use Eminiarts\Tabs\Tab;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Support\Str;
 
 class TabTest extends TestCase
 {
@@ -126,16 +127,29 @@ class TabTest extends TestCase
         ], $tab->toArray()['bodyClass']);
     }
 
+    public function testCanSetCustomSlugGenerationFunction(): void
+    {
+        Tab::createSlugUsing(fn (Tab $tab) => strrev(Str::slug($tab->getTitle())));
+
+        $tab = Tab::make('Test tab', []);
+
+        self::assertSame('bat-tset', $tab->getSlug());
+    }
+
     /**
      * @link https://github.com/eminiarts/nova-tabs/issues/145
+     * @link https://github.com/eminiarts/nova-tabs/issues/167
+     * @link https://github.com/eminiarts/nova-tabs/issues/275
      *
      * @dataProvider multibyteTitleProvider
      */
-    public function testDoesNotCrashWithMultibyteCharactersAsTitle(string $title): void
+    public function testCanHandleSlugsInNonAsciiCharacters(string $title): void
     {
+        Tab::createSlugUsing(fn (Tab $tab) => $tab->getTitle());
+
         $tab = Tab::make($title, []);
 
-        self::assertEmpty($tab->getSlug());
+        self::assertSame($title, $tab->getSlug());
     }
 
     /**


### PR DESCRIPTION
Closes #249

This PR adds the ability to specify how slugs are generated. It's mainly targeted to non-Latin alphabet developers who otherwise need to use ASCII characters (or anything that can fit in `Str::slug`) in order for tabs to work.

Unfortunately, due to a missing Nova 4 license, I'm unable to test this in an application. I did write some unit tests to hopefully cover for this. However, again due to a missing license, I'm unable to properly run those.

Some help will be needed to verify this is working.